### PR TITLE
display-mode is not supported by Samsung Browser

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -660,7 +660,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": null


### PR DESCRIPTION
`display-mode` does not work for Samsung Browser. A bug about this can be found at https://github.com/SamsungInternet/support/issues/45

Manual testing shows that CSS selectors (as in `@media all and (display-mode: standalone) {`) for standalone and fullscreen do not work. The javascript query `window.matchMedia('(display-mode: standalone)').matches` for standalone and fullscreen return false. Only the query `window.matchMedia('(display-mode: browser)').matches` returns true for both standalone and fullscreen.